### PR TITLE
feat: add light/dark theme toggle

### DIFF
--- a/src/components/organisms/header/index.tsx
+++ b/src/components/organisms/header/index.tsx
@@ -8,10 +8,8 @@ const Header: FC = () => {
   const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
   const [isOnline, setIsOnline] = useState(false);
   const { data: health } = useEngramHealth();
-  const { theme, toggleTheme } = useThemeStore((state) => ({
-    theme: state.theme,
-    toggleTheme: state.toggleTheme
-  }));
+  const theme = useThemeStore((state) => state.theme);
+  const toggleTheme = useThemeStore((state) => state.toggleTheme);
 
   useEffect(() => {
     if (health?.status === 'ok') {

--- a/src/components/organisms/header/index.tsx
+++ b/src/components/organisms/header/index.tsx
@@ -1,12 +1,14 @@
-import { Wifi, WifiOff } from 'lucide-react';
+import { Moon, Sun, Wifi, WifiOff } from 'lucide-react';
 import { type FC, useEffect, useState } from 'react';
 import { cn } from 'tailwind-variants';
 import { useEngramHealth } from '@/hooks/use-engram';
+import { useTheme } from '@/hooks/use-theme/hook';
 
 const Header: FC = () => {
   const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
   const [isOnline, setIsOnline] = useState(false);
   const { data: health } = useEngramHealth();
+  const { theme, toggleTheme } = useTheme();
 
   useEffect(() => {
     if (health?.status === 'ok') {
@@ -32,7 +34,15 @@ const Header: FC = () => {
           {lastUpdated ? `Updated ${lastUpdated.toLocaleTimeString()}` : 'polling every 2 s'}
         </p>
       </div>
-      <div className='flex items-center gap-2'>
+      <div className='flex items-center gap-3'>
+        <button
+          type='button'
+          onClick={toggleTheme}
+          className='flex items-center justify-center w-8 h-8 rounded-full border border-gray-light-300 dark:border-gray-dark-700 text-gray-light-700 dark:text-gray-dark-300 hover:bg-gray-light-200 dark:hover:bg-gray-dark-800 transition-colors cursor-pointer'
+          title={theme === 'dark' ? 'Cambiar a light mode' : 'Cambiar a dark mode'}
+        >
+          {theme === 'dark' ? <Sun size={14} strokeWidth={1.5} /> : <Moon size={14} strokeWidth={1.5} />}
+        </button>
         <span
           className={cn(
             'flex items-center gap-1.5 text-[11px] font-mono px-2 py-1 rounded-full border',

--- a/src/components/organisms/header/index.tsx
+++ b/src/components/organisms/header/index.tsx
@@ -8,8 +8,10 @@ const Header: FC = () => {
   const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
   const [isOnline, setIsOnline] = useState(false);
   const { data: health } = useEngramHealth();
-  const theme = useThemeStore((state) => state.theme);
-  const toggleTheme = useThemeStore((state) => state.toggleTheme);
+  const { theme, toggleTheme } = useThemeStore((state) => ({
+    theme: state.theme,
+    toggleTheme: state.toggleTheme
+  }));
 
   useEffect(() => {
     if (health?.status === 'ok') {

--- a/src/components/organisms/header/index.tsx
+++ b/src/components/organisms/header/index.tsx
@@ -1,14 +1,15 @@
 import { Moon, Sun, Wifi, WifiOff } from 'lucide-react';
 import { type FC, useEffect, useState } from 'react';
 import { cn } from 'tailwind-variants';
-import { useEngramHealth } from '@/hooks/use-engram';
-import { useTheme } from '@/hooks/use-theme/hook';
+import { useEngramHealth } from '@hooks/use-engram';
+import { useThemeStore } from '@hooks/use-theme';
 
 const Header: FC = () => {
   const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
   const [isOnline, setIsOnline] = useState(false);
   const { data: health } = useEngramHealth();
-  const { theme, toggleTheme } = useTheme();
+  const theme = useThemeStore((state) => state.theme);
+  const toggleTheme = useThemeStore((state) => state.toggleTheme);
 
   useEffect(() => {
     if (health?.status === 'ok') {
@@ -39,9 +40,15 @@ const Header: FC = () => {
           type='button'
           onClick={toggleTheme}
           className='flex items-center justify-center w-8 h-8 rounded-full border border-gray-light-300 dark:border-gray-dark-700 text-gray-light-700 dark:text-gray-dark-300 hover:bg-gray-light-200 dark:hover:bg-gray-dark-800 transition-colors cursor-pointer'
-          title={theme === 'dark' ? 'Cambiar a light mode' : 'Cambiar a dark mode'}
+          title={theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
+          aria-label={theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
+          aria-pressed={theme === 'dark'}
         >
-          {theme === 'dark' ? <Sun size={14} strokeWidth={1.5} /> : <Moon size={14} strokeWidth={1.5} />}
+          {theme === 'dark' ? (
+            <Sun size={14} strokeWidth={1.5} aria-hidden='true' />
+          ) : (
+            <Moon size={14} strokeWidth={1.5} aria-hidden='true' />
+          )}
         </button>
         <span
           className={cn(

--- a/src/hooks/use-theme/hook.ts
+++ b/src/hooks/use-theme/hook.ts
@@ -30,6 +30,7 @@ export const useTheme = () => {
     }
 
     const root = document.documentElement;
+    root.classList.remove('light', 'dark');
     root.classList.add(themeParsed ? themeParsed : theme);
   }, [theme, setTheme]);
 

--- a/src/hooks/use-theme/hook.ts
+++ b/src/hooks/use-theme/hook.ts
@@ -25,25 +25,34 @@ export const useTheme = () => {
   const setTheme = useThemeStore((state) => state.setTheme);
   const toggleTheme = useThemeStore((state) => state.toggleTheme);
 
-  // Listen for system preference changes when no stored theme
+  // Listen for system preference changes — only respond when no user preference is stored
   useEffect(() => {
-    if (getStoredTheme()) return;
-
     const mql = window.matchMedia('(prefers-color-scheme: dark)');
     const handleChange = () => {
-      setTheme(mql.matches ? 'dark' : 'light');
+      if (!getStoredTheme()) {
+        setTheme(mql.matches ? 'dark' : 'light');
+      }
     };
-    mql.addEventListener('change', handleChange);
+
+    if (!getStoredTheme()) {
+      mql.addEventListener('change', handleChange);
+    }
+
     return () => mql.removeEventListener('change', handleChange);
   }, [setTheme]);
 
-  // Apply theme class to document
+  // Apply theme class to document — use store value as primary, fall back to system preference
   useEffect(() => {
     const stored = getStoredTheme();
-    const effectiveTheme = stored ?? (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+    const effectiveTheme = stored ?? theme;
 
     if (!stored) {
-      setTheme(effectiveTheme);
+      const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+      const systemTheme = prefersDark ? 'dark' : 'light';
+      if (theme !== systemTheme) {
+        setTheme(systemTheme);
+        return; // Will re-run with updated theme
+      }
     }
 
     const root = document.documentElement;

--- a/src/hooks/use-theme/hook.ts
+++ b/src/hooks/use-theme/hook.ts
@@ -1,44 +1,51 @@
 import { useEffect } from 'react';
 import { useThemeStore } from './store';
 
+/** Reads and validates the persisted theme. Returns undefined if missing/invalid. */
+function getStoredTheme(): 'light' | 'dark' | undefined {
+  try {
+    const raw = localStorage.getItem('app-theme');
+    if (!raw) return undefined;
+    const parsed = JSON.parse(raw);
+    const value = parsed.state?.theme;
+    if (value === 'light' || value === 'dark') return value;
+    // Invalid value — remove so system preference listener can attach
+    localStorage.removeItem('app-theme');
+  } catch {
+    localStorage.removeItem('app-theme');
+  }
+  return undefined;
+}
+
 export const useTheme = () => {
   const theme = useThemeStore((state) => state.theme);
   const setTheme = useThemeStore((state) => state.setTheme);
   const toggleTheme = useThemeStore((state) => state.toggleTheme);
 
+  // Listen for system preference changes when no stored theme
   useEffect(() => {
+    if (getStoredTheme()) return;
+
     const mql = window.matchMedia('(prefers-color-scheme: dark)');
     const handleChange = () => {
       setTheme(mql.matches ? 'dark' : 'light');
     };
-
-    if (!localStorage.getItem('app-theme')) {
-      mql.addEventListener('change', handleChange);
-    }
-
+    mql.addEventListener('change', handleChange);
     return () => mql.removeEventListener('change', handleChange);
-  }, []);
+  }, [setTheme]);
 
+  // Apply theme class to document
   useEffect(() => {
-    let themeParsed: string | undefined;
-    try {
-      const storedTheme = localStorage.getItem('app-theme');
-      const parsed = JSON.parse(storedTheme || '{}');
-      if (parsed.state?.theme === 'light' || parsed.state?.theme === 'dark') {
-        themeParsed = parsed.state.theme;
-      }
-    } catch {
-      // Malformed localStorage — fall through to system preference
-    }
+    const stored = getStoredTheme();
+    const effectiveTheme = stored ?? (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
 
-    if (!themeParsed) {
-      const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-      setTheme(prefersDark ? 'dark' : 'light');
+    if (!stored) {
+      setTheme(effectiveTheme);
     }
 
     const root = document.documentElement;
     root.classList.remove('light', 'dark');
-    root.classList.add(themeParsed ?? theme);
+    root.classList.add(effectiveTheme);
   }, [theme, setTheme]);
 
   return {

--- a/src/hooks/use-theme/hook.ts
+++ b/src/hooks/use-theme/hook.ts
@@ -9,10 +9,13 @@ function getStoredTheme(): 'light' | 'dark' | undefined {
     const parsed = JSON.parse(raw);
     const value = parsed.state?.theme;
     if (value === 'light' || value === 'dark') return value;
-    // Invalid value — remove so system preference listener can attach
+  } catch {
+    // Malformed JSON or storage unavailable
+  }
+  try {
     localStorage.removeItem('app-theme');
   } catch {
-    localStorage.removeItem('app-theme');
+    // Storage access blocked — ignore
   }
   return undefined;
 }

--- a/src/hooks/use-theme/hook.ts
+++ b/src/hooks/use-theme/hook.ts
@@ -20,9 +20,16 @@ export const useTheme = () => {
   }, []);
 
   useEffect(() => {
-    const storedTheme = localStorage.getItem('app-theme');
-    const parsed = JSON.parse(storedTheme || '{}');
-    const themeParsed = parsed.state?.theme;
+    let themeParsed: string | undefined;
+    try {
+      const storedTheme = localStorage.getItem('app-theme');
+      const parsed = JSON.parse(storedTheme || '{}');
+      if (parsed.state?.theme === 'light' || parsed.state?.theme === 'dark') {
+        themeParsed = parsed.state.theme;
+      }
+    } catch {
+      // Malformed localStorage — fall through to system preference
+    }
 
     if (!themeParsed) {
       const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
@@ -31,7 +38,7 @@ export const useTheme = () => {
 
     const root = document.documentElement;
     root.classList.remove('light', 'dark');
-    root.classList.add(themeParsed ? themeParsed : theme);
+    root.classList.add(themeParsed ?? theme);
   }, [theme, setTheme]);
 
   return {


### PR DESCRIPTION
## Summary
  - Added sun/moon toggle button in the header to switch between light and dark mode
  - Fixed bug in useTheme hook: classList was not removing the previous theme class on toggle

  ## Details
  - Light mode CSS variables were already defined in theme.css but no UI toggle existed
  - Uses Sun and Moon icons from lucide-react (already a dependency)
  - Toggle calls the existing toggleTheme() from the Zustand store

  ## Files changed
  - src/components/organisms/header/index.tsx - Added theme toggle button
  - src/hooks/use-theme/hook.ts - Fixed classList cleanup on theme change