### PR TITLE
feat: inline observation editing

### DIFF
--- a/src/components/molecules/markdown-panel/MarkdownPanel.tsx
+++ b/src/components/molecules/markdown-panel/MarkdownPanel.tsx
@@ -11,14 +11,19 @@ import type { MarkdownPanelProps } from './types';
 
 const MARKED_OPTIONS: MarkedOptions = { async: false };
 
+/** Escapes HTML special characters to prevent XSS in rendered attributes/content. */
+function escapeHtml(str: string): string {
+  return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+}
+
 // Strip raw HTML and sanitize links in markdown content
 marked.use({
   renderer: {
     html: () => '',
     link: ({ href, title, text }) => {
-      const safeHref = href && /^https?:\/\//i.test(href) ? href : '#';
-      const titleAttr = title ? ` title="${title}"` : '';
-      return `<a href="${safeHref}"${titleAttr} rel="noopener noreferrer">${text}</a>`;
+      const safeHref = href && /^https?:\/\//i.test(href) ? escapeHtml(href) : '#';
+      const titleAttr = title ? ` title="${escapeHtml(title)}"` : '';
+      return `<a href="${safeHref}"${titleAttr} rel="noopener noreferrer">${escapeHtml(text)}</a>`;
     }
   }
 });
@@ -81,8 +86,9 @@ const MarkdownPanel: FC<MarkdownPanelProps> = ({ observation: initialObs, onClos
     setType(currentObs.type);
     setScope(currentObs.scope);
     setTopicKey(currentObs.topic_key ?? '');
+    updateMutation.reset();
     setEditing(false);
-  }, [currentObs]);
+  }, [currentObs, updateMutation]);
 
   // Esc key handler with proper deps
   useEffect(() => {
@@ -127,7 +133,10 @@ const MarkdownPanel: FC<MarkdownPanelProps> = ({ observation: initialObs, onClos
 
   return (
     <>
-      <div className='fixed inset-0 z-40 bg-black/40 backdrop-blur-sm' onClick={editing ? handleCancel : onClose} />
+      <div
+        className='fixed inset-0 z-40 bg-black/40 backdrop-blur-sm'
+        onClick={() => { if (!updateMutation.isPending) { editing ? handleCancel() : onClose(); } }}
+      />
       <div
         className={cn(
           'fixed top-0 right-0 z-50 h-full w-full max-w-160',
@@ -270,8 +279,8 @@ const MarkdownPanel: FC<MarkdownPanelProps> = ({ observation: initialObs, onClos
           )}
         </div>
 
-        {/* Error feedback */}
-        {updateMutation.isError && (
+        {/* Error feedback — only visible in edit mode */}
+        {editing && updateMutation.isError && (
           <div className='px-6 py-3 border-t border-red-400/30 bg-red-400/10 text-red-400 text-[12px] font-mono'>
             Error: {updateMutation.error instanceof Error ? updateMutation.error.message : 'Failed to update observation'}
           </div>

--- a/src/components/molecules/markdown-panel/MarkdownPanel.tsx
+++ b/src/components/molecules/markdown-panel/MarkdownPanel.tsx
@@ -5,7 +5,16 @@ import { cn } from '@helpers/utils';
 import { useUpdateObservation } from '@hooks/use-engram';
 import type { EngramObservation, EngramObservationUpdate, EngramObservationType, EngramScope } from '@models/engram';
 import { Check, FolderOpen, Pencil, Shield, Tag, X } from 'lucide-react';
-import { marked } from 'marked';
+import { type MarkedOptions, marked } from 'marked';
+
+const MARKED_OPTIONS: MarkedOptions = { async: false };
+
+// Configure marked to sanitize raw HTML in markdown content
+marked.use({
+  renderer: {
+    html: () => ''
+  }
+});
 import { type FC, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { MarkdownPanelProps } from './types';
 
@@ -57,11 +66,7 @@ const MarkdownPanel: FC<MarkdownPanelProps> = ({ observation: initialObs, onClos
   // Render markdown content
   useEffect(() => {
     if (contentRef.current && !editing) {
-      const html = marked(currentObs.content, { async: false }) as string;
-      contentRef.current.textContent = '';
-      const template = document.createElement('template');
-      template.innerHTML = html;
-      contentRef.current.appendChild(template.content);
+      contentRef.current.innerHTML = marked(currentObs.content, MARKED_OPTIONS) as string;
     }
   }, [currentObs.content, editing]);
 
@@ -117,7 +122,7 @@ const MarkdownPanel: FC<MarkdownPanelProps> = ({ observation: initialObs, onClos
 
   return (
     <>
-      <div className='fixed inset-0 z-40 bg-black/40 backdrop-blur-sm' onClick={onClose} />
+      <div className='fixed inset-0 z-40 bg-black/40 backdrop-blur-sm' onClick={editing ? handleCancel : onClose} />
       <div
         className={cn(
           'fixed top-0 right-0 z-50 h-full w-full max-w-160',
@@ -134,6 +139,7 @@ const MarkdownPanel: FC<MarkdownPanelProps> = ({ observation: initialObs, onClos
                 type='text'
                 value={title}
                 onChange={(e) => setTitle(e.target.value)}
+                aria-label='Title'
                 className={cn(INPUT_CLS, 'text-sm font-semibold w-full')}
               />
             ) : (
@@ -147,6 +153,7 @@ const MarkdownPanel: FC<MarkdownPanelProps> = ({ observation: initialObs, onClos
                 <select
                   value={type}
                   onChange={(e) => setType(e.target.value)}
+                  aria-label='Type'
                   className={cn(INPUT_CLS, 'py-1 text-[11px]')}
                 >
                   {typeOptions.map((t) => (
@@ -171,6 +178,7 @@ const MarkdownPanel: FC<MarkdownPanelProps> = ({ observation: initialObs, onClos
                     type='text'
                     value={topicKey}
                     onChange={(e) => setTopicKey(e.target.value)}
+                    aria-label='Topic key'
                     placeholder='topic_key'
                     className={cn(INPUT_CLS, 'py-1 text-[10px] w-40')}
                   />
@@ -194,6 +202,7 @@ const MarkdownPanel: FC<MarkdownPanelProps> = ({ observation: initialObs, onClos
                 <select
                   value={scope}
                   onChange={(e) => setScope(e.target.value)}
+                  aria-label='Scope'
                   className={cn(INPUT_CLS, 'py-1 text-[10px]')}
                 >
                   {scopeOptions.map((s) => (
@@ -248,6 +257,7 @@ const MarkdownPanel: FC<MarkdownPanelProps> = ({ observation: initialObs, onClos
             <textarea
               value={content}
               onChange={(e) => setContent(e.target.value)}
+              aria-label='Content'
               className={cn(INPUT_CLS, 'w-full h-full min-h-60 resize-none font-mono text-[13px] leading-relaxed')}
             />
           ) : (

--- a/src/components/molecules/markdown-panel/MarkdownPanel.tsx
+++ b/src/components/molecules/markdown-panel/MarkdownPanel.tsx
@@ -6,17 +6,22 @@ import { useUpdateObservation } from '@hooks/use-engram';
 import type { EngramObservation, EngramObservationUpdate, EngramObservationType, EngramScope } from '@models/engram';
 import { Check, FolderOpen, Pencil, Shield, Tag, X } from 'lucide-react';
 import { type MarkedOptions, marked } from 'marked';
+import { type FC, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { MarkdownPanelProps } from './types';
 
 const MARKED_OPTIONS: MarkedOptions = { async: false };
 
-// Configure marked to sanitize raw HTML in markdown content
+// Strip raw HTML and sanitize links in markdown content
 marked.use({
   renderer: {
-    html: () => ''
+    html: () => '',
+    link: ({ href, title, text }) => {
+      const safeHref = href && /^https?:\/\//i.test(href) ? href : '#';
+      const titleAttr = title ? ` title="${title}"` : '';
+      return `<a href="${safeHref}"${titleAttr} rel="noopener noreferrer">${text}</a>`;
+    }
   }
 });
-import { type FC, useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import type { MarkdownPanelProps } from './types';
 
 const BASE_SCOPES: EngramScope[] = ['project', 'personal', 'global'];
 
@@ -51,17 +56,17 @@ const MarkdownPanel: FC<MarkdownPanelProps> = ({ observation: initialObs, onClos
     return scopes;
   }, [currentObs.scope]);
 
-  // Sync from polling when not editing
+  // Sync from polling — only when initialObs changes and not editing
   useEffect(() => {
-    if (!editing) {
-      setCurrentObs(initialObs);
-      setTitle(initialObs.title);
-      setContent(initialObs.content);
-      setType(initialObs.type);
-      setScope(initialObs.scope);
-      setTopicKey(initialObs.topic_key ?? '');
-    }
-  }, [initialObs, editing]);
+    if (editing) return;
+
+    setCurrentObs(initialObs);
+    setTitle(initialObs.title);
+    setContent(initialObs.content);
+    setType(initialObs.type);
+    setScope(initialObs.scope);
+    setTopicKey(initialObs.topic_key ?? '');
+  }, [initialObs]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Render markdown content
   useEffect(() => {
@@ -268,7 +273,7 @@ const MarkdownPanel: FC<MarkdownPanelProps> = ({ observation: initialObs, onClos
         {/* Error feedback */}
         {updateMutation.isError && (
           <div className='px-6 py-3 border-t border-red-400/30 bg-red-400/10 text-red-400 text-[12px] font-mono'>
-            Error: {updateMutation.error?.message ?? 'Failed to update observation'}
+            Error: {updateMutation.error instanceof Error ? updateMutation.error.message : 'Failed to update observation'}
           </div>
         )}
       </div>

--- a/src/components/molecules/markdown-panel/MarkdownPanel.tsx
+++ b/src/components/molecules/markdown-panel/MarkdownPanel.tsx
@@ -94,6 +94,7 @@ const MarkdownPanel: FC<MarkdownPanelProps> = ({ observation: initialObs, onClos
   useEffect(() => {
     const handleKey = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
+        if (updateMutation.isPending) return;
         if (editing) {
           handleCancel();
         } else {

--- a/src/components/molecules/markdown-panel/MarkdownPanel.tsx
+++ b/src/components/molecules/markdown-panel/MarkdownPanel.tsx
@@ -1,29 +1,92 @@
 import { IconButton } from '@atoms/icon-button';
 import { TypeBadge } from '@atoms/type-badge';
+import { INPUT_CLS, KNOWN_TYPES } from '@constants/engram-types';
 import { cn } from '@helpers/utils';
-import { FolderOpen, Shield, Tag, X } from 'lucide-react';
+import { useUpdateObservation } from '@hooks/use-engram';
+import type { EngramObservationType, EngramScope } from '@models/engram';
+import { Check, FolderOpen, Pencil, Shield, Tag, X } from 'lucide-react';
 import { marked } from 'marked';
-import { type FC, useEffect, useRef } from 'react';
+import { type FC, useEffect, useRef, useState } from 'react';
 import type { MarkdownPanelProps } from './types';
 
-const MarkdownPanel: FC<MarkdownPanelProps> = ({ observation: obs, onClose }) => {
+const SCOPE_OPTIONS: EngramScope[] = ['project', 'personal', 'global'];
+
+const MarkdownPanel: FC<MarkdownPanelProps> = ({ observation: obs, onClose, onUpdated }) => {
   const contentRef = useRef<HTMLDivElement>(null);
+  const [editing, setEditing] = useState(false);
+
+  const [title, setTitle] = useState(obs.title);
+  const [content, setContent] = useState(obs.content);
+  const [type, setType] = useState<EngramObservationType>(obs.type);
+  const [scope, setScope] = useState<EngramScope>(obs.scope);
+  const [topicKey, setTopicKey] = useState(obs.topic_key ?? '');
+
+  const updateMutation = useUpdateObservation();
+
+  // Sync local state when observation changes (e.g. polling update)
+  useEffect(() => {
+    if (!editing) {
+      setTitle(obs.title);
+      setContent(obs.content);
+      setType(obs.type);
+      setScope(obs.scope);
+      setTopicKey(obs.topic_key ?? '');
+    }
+  }, [obs, editing]);
 
   useEffect(() => {
-    if (contentRef.current) {
+    if (contentRef.current && !editing) {
       contentRef.current.innerHTML = marked(obs.content, { async: false }) as string;
     }
-  }, [obs.content]);
+  }, [obs.content, editing]);
 
   useEffect(() => {
     const handleKey = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
-        onClose();
+        if (editing) {
+          handleCancel();
+        } else {
+          onClose();
+        }
       }
     };
     window.addEventListener('keydown', handleKey);
     return () => window.removeEventListener('keydown', handleKey);
-  }, [onClose]);
+  }, [onClose, editing]);
+
+  const handleCancel = () => {
+    setTitle(obs.title);
+    setContent(obs.content);
+    setType(obs.type);
+    setScope(obs.scope);
+    setTopicKey(obs.topic_key ?? '');
+    setEditing(false);
+  };
+
+  const handleSave = () => {
+    const data: Record<string, string | null | undefined> = {};
+    if (title !== obs.title) data.title = title;
+    if (content !== obs.content) data.content = content;
+    if (type !== obs.type) data.type = type;
+    if (scope !== obs.scope) data.scope = scope;
+    const newTopicKey = topicKey.trim() || null;
+    if (newTopicKey !== (obs.topic_key ?? null)) data.topic_key = newTopicKey;
+
+    if (Object.keys(data).length === 0) {
+      setEditing(false);
+      return;
+    }
+
+    updateMutation.mutate(
+      { id: obs.id, data },
+      {
+        onSuccess: (updated) => {
+          setEditing(false);
+          onUpdated?.(updated);
+        }
+      }
+    );
+  };
 
   return (
     <>
@@ -38,40 +101,137 @@ const MarkdownPanel: FC<MarkdownPanelProps> = ({ observation: obs, onClose }) =>
       >
         {/* Header */}
         <div className='flex items-start justify-between gap-4 px-6 py-4 border-b border-gray-light-300 dark:border-gray-dark-700'>
-          <div className='flex flex-col gap-1.5 min-w-0'>
-            <h2 className='text-sm font-semibold text-text-light dark:text-text-dark leading-snug'>{obs.title}</h2>
+          <div className='flex flex-col gap-1.5 min-w-0 flex-1'>
+            {editing ? (
+              <input
+                type='text'
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+                className={cn(INPUT_CLS, 'text-sm font-semibold w-full')}
+              />
+            ) : (
+              <h2 className='text-sm font-semibold text-text-light dark:text-text-dark leading-snug'>{obs.title}</h2>
+            )}
+
             <div className='flex items-center gap-2 flex-wrap'>
-              <TypeBadge type={obs.type} />
-              {obs.project && (
+              {editing ? (
+                <select
+                  value={type}
+                  onChange={(e) => setType(e.target.value)}
+                  className={cn(INPUT_CLS, 'py-1 text-[11px]')}
+                >
+                  {KNOWN_TYPES.map((t) => (
+                    <option key={t} value={t}>
+                      {t}
+                    </option>
+                  ))}
+                </select>
+              ) : (
+                <TypeBadge type={obs.type} />
+              )}
+              {obs.project && !editing && (
                 <span className='inline-flex items-center gap-1 text-[11px] font-mono text-gray-light-600 dark:text-gray-dark-300'>
                   <FolderOpen size={10} className='opacity-60 shrink-0' />
                   {obs.project}
                 </span>
               )}
-              {obs.topic_key && (
-                <span className='inline-flex items-center gap-1 text-[10px] font-mono text-gray-light-500 dark:text-gray-dark-300'>
+              {editing ? (
+                <div className='flex items-center gap-1'>
                   <Tag size={9} className='text-gray-light-400 dark:text-gray-dark-300 shrink-0' />
-                  {obs.topic_key}
-                </span>
+                  <input
+                    type='text'
+                    value={topicKey}
+                    onChange={(e) => setTopicKey(e.target.value)}
+                    placeholder='topic_key'
+                    className={cn(INPUT_CLS, 'py-1 text-[10px] w-40')}
+                  />
+                </div>
+              ) : (
+                obs.topic_key && (
+                  <span className='inline-flex items-center gap-1 text-[10px] font-mono text-gray-light-500 dark:text-gray-dark-300'>
+                    <Tag size={9} className='text-gray-light-400 dark:text-gray-dark-300 shrink-0' />
+                    {obs.topic_key}
+                  </span>
+                )
               )}
               <span className='text-[11px] font-mono text-gray-light-500 dark:text-gray-dark-300'>
                 {new Date(obs.created_at).toLocaleString()}
               </span>
             </div>
-            {obs.scope && obs.scope !== 'project' && (
-              <span className='inline-flex items-center gap-1 text-[10px] font-mono text-gray-light-400 dark:text-gray-dark-300'>
-                <Shield size={9} className='shrink-0' />
-                {obs.scope}
-              </span>
+
+            {editing ? (
+              <div className='flex items-center gap-1'>
+                <Shield size={9} className='shrink-0 text-gray-light-400 dark:text-gray-dark-300' />
+                <select
+                  value={scope}
+                  onChange={(e) => setScope(e.target.value)}
+                  className={cn(INPUT_CLS, 'py-1 text-[10px]')}
+                >
+                  {SCOPE_OPTIONS.map((s) => (
+                    <option key={s} value={s}>
+                      {s}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            ) : (
+              obs.scope &&
+              obs.scope !== 'project' && (
+                <span className='inline-flex items-center gap-1 text-[10px] font-mono text-gray-light-400 dark:text-gray-dark-300'>
+                  <Shield size={9} className='shrink-0' />
+                  {obs.scope}
+                </span>
+              )
             )}
           </div>
-          <IconButton icon={X} size={16} label='Close' onClick={onClose} className='mt-0.5' />
+
+          <div className='flex items-center gap-2 mt-0.5'>
+            {editing ? (
+              <>
+                <IconButton icon={X} size={16} label='Cancel' onClick={handleCancel} />
+                <button
+                  type='button'
+                  onClick={handleSave}
+                  disabled={updateMutation.isPending}
+                  className={cn(
+                    'flex items-center gap-1 px-2.5 py-1 rounded-md text-[11px] font-mono',
+                    'bg-green/20 text-green border border-green/30',
+                    'hover:bg-green/30 transition-colors',
+                    'disabled:opacity-50 disabled:cursor-not-allowed'
+                  )}
+                >
+                  <Check size={12} />
+                  {updateMutation.isPending ? 'Saving…' : 'Save'}
+                </button>
+              </>
+            ) : (
+              <>
+                <IconButton icon={Pencil} size={14} label='Edit' onClick={() => setEditing(true)} />
+                <IconButton icon={X} size={16} label='Close' onClick={onClose} />
+              </>
+            )}
+          </div>
         </div>
 
         {/* Body */}
         <div className='flex-1 overflow-y-auto px-6 py-5'>
-          <div ref={contentRef} className='markdown-body text-[13px] text-text-light dark:text-text-dark' />
+          {editing ? (
+            <textarea
+              value={content}
+              onChange={(e) => setContent(e.target.value)}
+              className={cn(INPUT_CLS, 'w-full h-full min-h-60 resize-none font-mono text-[13px] leading-relaxed')}
+            />
+          ) : (
+            <div ref={contentRef} className='markdown-body text-[13px] text-text-light dark:text-text-dark' />
+          )}
         </div>
+
+        {/* Error feedback */}
+        {updateMutation.isError && (
+          <div className='px-6 py-3 border-t border-red-400/30 bg-red-400/10 text-red-400 text-[12px] font-mono'>
+            Error: {updateMutation.error?.message ?? 'Failed to update observation'}
+          </div>
+        )}
       </div>
     </>
   );

--- a/src/components/molecules/markdown-panel/MarkdownPanel.tsx
+++ b/src/components/molecules/markdown-panel/MarkdownPanel.tsx
@@ -3,43 +3,78 @@ import { TypeBadge } from '@atoms/type-badge';
 import { INPUT_CLS, KNOWN_TYPES } from '@constants/engram-types';
 import { cn } from '@helpers/utils';
 import { useUpdateObservation } from '@hooks/use-engram';
-import type { EngramObservationType, EngramScope } from '@models/engram';
+import type { EngramObservation, EngramObservationUpdate, EngramObservationType, EngramScope } from '@models/engram';
 import { Check, FolderOpen, Pencil, Shield, Tag, X } from 'lucide-react';
 import { marked } from 'marked';
-import { type FC, useEffect, useRef, useState } from 'react';
+import { type FC, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { MarkdownPanelProps } from './types';
 
-const SCOPE_OPTIONS: EngramScope[] = ['project', 'personal', 'global'];
+const BASE_SCOPES: EngramScope[] = ['project', 'personal', 'global'];
 
-const MarkdownPanel: FC<MarkdownPanelProps> = ({ observation: obs, onClose, onUpdated }) => {
+const MarkdownPanel: FC<MarkdownPanelProps> = ({ observation: initialObs, onClose, onUpdated }) => {
   const contentRef = useRef<HTMLDivElement>(null);
   const [editing, setEditing] = useState(false);
+  const [currentObs, setCurrentObs] = useState<EngramObservation>(initialObs);
 
-  const [title, setTitle] = useState(obs.title);
-  const [content, setContent] = useState(obs.content);
-  const [type, setType] = useState<EngramObservationType>(obs.type);
-  const [scope, setScope] = useState<EngramScope>(obs.scope);
-  const [topicKey, setTopicKey] = useState(obs.topic_key ?? '');
+  const [title, setTitle] = useState(currentObs.title);
+  const [content, setContent] = useState(currentObs.content);
+  const [type, setType] = useState<EngramObservationType>(currentObs.type);
+  const [scope, setScope] = useState<EngramScope>(currentObs.scope);
+  const [topicKey, setTopicKey] = useState(currentObs.topic_key ?? '');
 
   const updateMutation = useUpdateObservation();
 
-  // Sync local state when observation changes (e.g. polling update)
+  // Build type options: KNOWN_TYPES + current type if custom
+  const typeOptions = useMemo(() => {
+    const types = [...KNOWN_TYPES] as string[];
+    if (currentObs.type && !types.includes(currentObs.type)) {
+      types.push(currentObs.type);
+    }
+    return types;
+  }, [currentObs.type]);
+
+  // Build scope options: BASE_SCOPES + current scope if custom
+  const scopeOptions = useMemo(() => {
+    const scopes = [...BASE_SCOPES];
+    if (currentObs.scope && !scopes.includes(currentObs.scope)) {
+      scopes.push(currentObs.scope);
+    }
+    return scopes;
+  }, [currentObs.scope]);
+
+  // Sync from polling when not editing
   useEffect(() => {
     if (!editing) {
-      setTitle(obs.title);
-      setContent(obs.content);
-      setType(obs.type);
-      setScope(obs.scope);
-      setTopicKey(obs.topic_key ?? '');
+      setCurrentObs(initialObs);
+      setTitle(initialObs.title);
+      setContent(initialObs.content);
+      setType(initialObs.type);
+      setScope(initialObs.scope);
+      setTopicKey(initialObs.topic_key ?? '');
     }
-  }, [obs, editing]);
+  }, [initialObs, editing]);
 
+  // Render markdown content
   useEffect(() => {
     if (contentRef.current && !editing) {
-      contentRef.current.innerHTML = marked(obs.content, { async: false }) as string;
+      const html = marked(currentObs.content, { async: false }) as string;
+      contentRef.current.textContent = '';
+      const template = document.createElement('template');
+      template.innerHTML = html;
+      contentRef.current.appendChild(template.content);
     }
-  }, [obs.content, editing]);
+  }, [currentObs.content, editing]);
 
+  const handleCancel = useCallback(() => {
+    setTitle(currentObs.title);
+    setContent(currentObs.content);
+    setType(currentObs.type);
+    setScope(currentObs.scope);
+    setTopicKey(currentObs.topic_key ?? '');
+    setEditing(false);
+  }, [currentObs]);
+
+  // Esc key handler with proper deps
   useEffect(() => {
     const handleKey = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
@@ -52,25 +87,16 @@ const MarkdownPanel: FC<MarkdownPanelProps> = ({ observation: obs, onClose, onUp
     };
     window.addEventListener('keydown', handleKey);
     return () => window.removeEventListener('keydown', handleKey);
-  }, [onClose, editing]);
-
-  const handleCancel = () => {
-    setTitle(obs.title);
-    setContent(obs.content);
-    setType(obs.type);
-    setScope(obs.scope);
-    setTopicKey(obs.topic_key ?? '');
-    setEditing(false);
-  };
+  }, [onClose, editing, handleCancel]);
 
   const handleSave = () => {
-    const data: Record<string, string | null | undefined> = {};
-    if (title !== obs.title) data.title = title;
-    if (content !== obs.content) data.content = content;
-    if (type !== obs.type) data.type = type;
-    if (scope !== obs.scope) data.scope = scope;
+    const data: EngramObservationUpdate = {};
+    if (title !== currentObs.title) data.title = title;
+    if (content !== currentObs.content) data.content = content;
+    if (type !== currentObs.type) data.type = type;
+    if (scope !== currentObs.scope) data.scope = scope;
     const newTopicKey = topicKey.trim() || null;
-    if (newTopicKey !== (obs.topic_key ?? null)) data.topic_key = newTopicKey;
+    if (newTopicKey !== (currentObs.topic_key ?? null)) data.topic_key = newTopicKey;
 
     if (Object.keys(data).length === 0) {
       setEditing(false);
@@ -78,9 +104,10 @@ const MarkdownPanel: FC<MarkdownPanelProps> = ({ observation: obs, onClose, onUp
     }
 
     updateMutation.mutate(
-      { id: obs.id, data },
+      { id: currentObs.id, data },
       {
         onSuccess: (updated) => {
+          setCurrentObs(updated);
           setEditing(false);
           onUpdated?.(updated);
         }
@@ -110,7 +137,9 @@ const MarkdownPanel: FC<MarkdownPanelProps> = ({ observation: obs, onClose, onUp
                 className={cn(INPUT_CLS, 'text-sm font-semibold w-full')}
               />
             ) : (
-              <h2 className='text-sm font-semibold text-text-light dark:text-text-dark leading-snug'>{obs.title}</h2>
+              <h2 className='text-sm font-semibold text-text-light dark:text-text-dark leading-snug'>
+                {currentObs.title}
+              </h2>
             )}
 
             <div className='flex items-center gap-2 flex-wrap'>
@@ -120,19 +149,19 @@ const MarkdownPanel: FC<MarkdownPanelProps> = ({ observation: obs, onClose, onUp
                   onChange={(e) => setType(e.target.value)}
                   className={cn(INPUT_CLS, 'py-1 text-[11px]')}
                 >
-                  {KNOWN_TYPES.map((t) => (
+                  {typeOptions.map((t) => (
                     <option key={t} value={t}>
                       {t}
                     </option>
                   ))}
                 </select>
               ) : (
-                <TypeBadge type={obs.type} />
+                <TypeBadge type={currentObs.type} />
               )}
-              {obs.project && !editing && (
+              {currentObs.project && !editing && (
                 <span className='inline-flex items-center gap-1 text-[11px] font-mono text-gray-light-600 dark:text-gray-dark-300'>
                   <FolderOpen size={10} className='opacity-60 shrink-0' />
-                  {obs.project}
+                  {currentObs.project}
                 </span>
               )}
               {editing ? (
@@ -147,15 +176,15 @@ const MarkdownPanel: FC<MarkdownPanelProps> = ({ observation: obs, onClose, onUp
                   />
                 </div>
               ) : (
-                obs.topic_key && (
+                currentObs.topic_key && (
                   <span className='inline-flex items-center gap-1 text-[10px] font-mono text-gray-light-500 dark:text-gray-dark-300'>
                     <Tag size={9} className='text-gray-light-400 dark:text-gray-dark-300 shrink-0' />
-                    {obs.topic_key}
+                    {currentObs.topic_key}
                   </span>
                 )
               )}
               <span className='text-[11px] font-mono text-gray-light-500 dark:text-gray-dark-300'>
-                {new Date(obs.created_at).toLocaleString()}
+                {new Date(currentObs.created_at).toLocaleString()}
               </span>
             </div>
 
@@ -167,7 +196,7 @@ const MarkdownPanel: FC<MarkdownPanelProps> = ({ observation: obs, onClose, onUp
                   onChange={(e) => setScope(e.target.value)}
                   className={cn(INPUT_CLS, 'py-1 text-[10px]')}
                 >
-                  {SCOPE_OPTIONS.map((s) => (
+                  {scopeOptions.map((s) => (
                     <option key={s} value={s}>
                       {s}
                     </option>
@@ -175,11 +204,11 @@ const MarkdownPanel: FC<MarkdownPanelProps> = ({ observation: obs, onClose, onUp
                 </select>
               </div>
             ) : (
-              obs.scope &&
-              obs.scope !== 'project' && (
+              currentObs.scope &&
+              currentObs.scope !== 'project' && (
                 <span className='inline-flex items-center gap-1 text-[10px] font-mono text-gray-light-400 dark:text-gray-dark-300'>
                   <Shield size={9} className='shrink-0' />
-                  {obs.scope}
+                  {currentObs.scope}
                 </span>
               )
             )}

--- a/src/components/molecules/markdown-panel/types.ts
+++ b/src/components/molecules/markdown-panel/types.ts
@@ -3,4 +3,5 @@ import type { EngramObservation } from '@models/engram';
 export interface MarkdownPanelProps {
   observation: EngramObservation;
   onClose: () => void;
+  onUpdated?: (updated: EngramObservation) => void;
 }

--- a/src/hooks/use-engram/hook.ts
+++ b/src/hooks/use-engram/hook.ts
@@ -1,3 +1,4 @@
+import type { EngramObservationUpdate } from '@models/engram';
 import { engramService } from '@services/engram';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useEffect, useRef, useState } from 'react';
@@ -100,6 +101,20 @@ export const useDeleteSession = () => {
     mutationFn: (id: string) => engramService.deleteSession(id),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['engram', 'session-summaries'] });
+      queryClient.invalidateQueries({ queryKey: ['engram', 'stats'] });
+    }
+  });
+};
+
+/** Update a single observation by ID. */
+export const useUpdateObservation = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, data }: { id: number; data: EngramObservationUpdate }) =>
+      engramService.updateObservation(id, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['engram', 'search'] });
+      queryClient.invalidateQueries({ queryKey: ['engram', 'sessions'] });
       queryClient.invalidateQueries({ queryKey: ['engram', 'stats'] });
     }
   });

--- a/src/hooks/use-engram/index.ts
+++ b/src/hooks/use-engram/index.ts
@@ -8,6 +8,7 @@ export {
   useEngramSearch,
   useEngramSessionSummaries,
   useEngramSessions,
-  useEngramStats
+  useEngramStats,
+  useUpdateObservation
 } from './hook';
 export type { EngramFilters } from './types';

--- a/src/models/engram.ts
+++ b/src/models/engram.ts
@@ -30,6 +30,14 @@ export interface EngramObservation {
   rank?: number;
 }
 
+export interface EngramObservationUpdate {
+  title?: string;
+  content?: string;
+  type?: EngramObservationType;
+  scope?: EngramScope;
+  topic_key?: string | null;
+}
+
 export interface EngramStats {
   total_sessions: number;
   total_observations: number;

--- a/src/services/engram.ts
+++ b/src/services/engram.ts
@@ -3,6 +3,7 @@ import type {
   EngramContext,
   EngramHealth,
   EngramObservation,
+  EngramObservationUpdate,
   EngramPrompt,
   EngramSearchParams,
   EngramSession,
@@ -38,6 +39,11 @@ export const engramService = {
 
   deleteObservation: async (id: number): Promise<void> => {
     await engramApi.delete(`/observations/${id}`);
+  },
+
+  updateObservation: async (id: number, data: EngramObservationUpdate): Promise<EngramObservation> => {
+    const { data: updated } = await engramApi.patch<EngramObservation>(`/observations/${id}`, data);
+    return updated;
   },
 
   /** Fetches all reachable observations via multiple broad FTS searches and deduplicates. */


### PR DESCRIPTION
## Summary
- Added edit mode in the observation detail panel (MarkdownPanel)
- Pencil icon toggles between read and edit mode
- Editable fields: title, content, type, scope, topic_key
- Uses PATCH /observations/{id} from the Engram API

## Implementation
- New EngramObservationUpdate type for partial updates
- New useUpdateObservation hook (React Query mutation with cache invalidation)
- New updateObservation method in engramService
- Edit mode shows form inputs, save/cancel buttons, error feedback
- Esc cancels edit, only changed fields are sent to the API

## Files changed
- src/models/engram.ts - Added EngramObservationUpdate interface
- src/services/engram.ts - Added updateObservation method
- src/hooks/use-engram/hook.ts - Added useUpdateObservation mutation
- src/hooks/use-engram/index.ts - Exported new hook
- src/components/molecules/markdown-panel/types.ts - Added onUpdated callback
- src/components/molecules/markdown-panel/MarkdownPanel.tsx - Full edit mode UI