### PR TITLE
feat: project consolidation modal

### DIFF
--- a/src/components/organisms/merge-projects-modal/MergeProjectsModal.tsx
+++ b/src/components/organisms/merge-projects-modal/MergeProjectsModal.tsx
@@ -1,0 +1,176 @@
+import { INPUT_CLS } from '@constants/engram-types';
+import { cn } from '@helpers/utils';
+import { ArrowRight, GitMerge, X } from 'lucide-react';
+import { type FC, useEffect, useId, useState } from 'react';
+import type { MergeProjectsModalProps } from './types';
+
+const MergeProjectsModal: FC<MergeProjectsModalProps> = ({ projects, onMerge, isMerging, onClose }) => {
+  const [from, setFrom] = useState('');
+  const [to, setTo] = useState('');
+  const titleId = useId();
+  const fromId = useId();
+  const toId = useId();
+
+  const targetOptions = projects.filter((p) => p !== from);
+  const canMerge = Boolean(from && to && from !== to && !isMerging);
+
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [onClose]);
+
+  // Reset target if it matches the new source
+  useEffect(() => {
+    if (to === from) setTo('');
+  }, [from, to]);
+
+  const handleMerge = () => {
+    if (!canMerge) return;
+    if (
+      !window.confirm(
+        `Merge all observations from "${from}" into "${to}"?\n\nThis action cannot be undone.`
+      )
+    )
+      return;
+    onMerge(from, to);
+  };
+
+  return (
+    <>
+      <button
+        type='button'
+        aria-label='Close dialog'
+        tabIndex={-1}
+        onClick={onClose}
+        disabled={isMerging}
+        className='fixed inset-0 z-40 bg-black/40 backdrop-blur-sm border-none cursor-default'
+      />
+      <div
+        role='dialog'
+        aria-modal='true'
+        aria-labelledby={titleId}
+        className={cn(
+          'fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 z-50',
+          'w-full max-w-md p-6 rounded-xl',
+          'bg-background-light dark:bg-background-dark',
+          'border border-gray-light-300 dark:border-gray-dark-700',
+          'shadow-xl flex flex-col gap-5'
+        )}
+      >
+        {/* Header */}
+        <div className='flex items-center justify-between'>
+          <div className='flex items-center gap-2'>
+            <GitMerge size={16} className='text-accent' />
+            <h2 id={titleId} className='text-sm font-semibold text-text-light dark:text-text-dark'>
+              Merge Projects
+            </h2>
+          </div>
+          <button
+            type='button'
+            onClick={onClose}
+            disabled={isMerging}
+            aria-label='Close'
+            className={cn(
+              'text-gray-light-600 dark:text-gray-dark-300 hover:text-text-light dark:hover:text-text-dark transition-colors',
+              isMerging && 'opacity-40 cursor-not-allowed'
+            )}
+          >
+            <X size={16} />
+          </button>
+        </div>
+
+        <p className='text-[12px] font-mono text-gray-light-600 dark:text-gray-dark-300 leading-relaxed'>
+          Move all observations from one project into another. The source project will be empty after merging.
+        </p>
+
+        {/* Selectors */}
+        <div className='flex items-center gap-3'>
+          <div className='flex-1 flex flex-col gap-1'>
+            <label
+              htmlFor={fromId}
+              className='text-[10px] font-mono uppercase tracking-widest text-gray-light-600 dark:text-gray-dark-300'
+            >
+              From
+            </label>
+            <select
+              id={fromId}
+              value={from}
+              onChange={(e) => setFrom(e.target.value)}
+              disabled={isMerging}
+              className={cn(INPUT_CLS, 'py-2 w-full', isMerging && 'opacity-50')}
+            >
+              <option value=''>Select source…</option>
+              {projects.map((p) => (
+                <option key={p} value={p}>
+                  {p}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <ArrowRight size={16} className='text-gray-light-400 dark:text-gray-dark-300 mt-4 shrink-0' />
+
+          <div className='flex-1 flex flex-col gap-1'>
+            <label
+              htmlFor={toId}
+              className='text-[10px] font-mono uppercase tracking-widest text-gray-light-600 dark:text-gray-dark-300'
+            >
+              Into
+            </label>
+            <select
+              id={toId}
+              value={to}
+              onChange={(e) => setTo(e.target.value)}
+              disabled={!from || isMerging}
+              className={cn(INPUT_CLS, 'py-2 w-full', (!from || isMerging) && 'opacity-50')}
+            >
+              <option value=''>Select target…</option>
+              {targetOptions.map((p) => (
+                <option key={p} value={p}>
+                  {p}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+
+        {/* Actions */}
+        <div className='flex justify-end gap-2'>
+          <button
+            type='button'
+            onClick={onClose}
+            disabled={isMerging}
+            className={cn(
+              'px-3 py-1.5 rounded-lg text-[11px] font-mono',
+              'border border-gray-light-400 dark:border-gray-dark-600',
+              'text-text-light dark:text-text-dark',
+              'hover:bg-gray-light-200 dark:hover:bg-gray-dark-800 transition-colors',
+              'disabled:opacity-40 disabled:cursor-not-allowed'
+            )}
+          >
+            Cancel
+          </button>
+          <button
+            type='button'
+            onClick={handleMerge}
+            disabled={!canMerge}
+            className={cn(
+              'flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-[11px] font-mono',
+              'bg-accent/20 text-accent border border-accent/30',
+              'hover:bg-accent/30 transition-colors',
+              'disabled:opacity-40 disabled:cursor-not-allowed'
+            )}
+          >
+            <GitMerge size={12} />
+            {isMerging ? 'Merging…' : 'Merge'}
+          </button>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default MergeProjectsModal;

--- a/src/components/organisms/merge-projects-modal/index.ts
+++ b/src/components/organisms/merge-projects-modal/index.ts
@@ -1,0 +1,2 @@
+export { default as MergeProjectsModal } from './MergeProjectsModal';
+export type { MergeProjectsModalProps } from './types';

--- a/src/components/organisms/merge-projects-modal/types.ts
+++ b/src/components/organisms/merge-projects-modal/types.ts
@@ -1,0 +1,6 @@
+export interface MergeProjectsModalProps {
+  projects: string[];
+  onMerge: (from: string, to: string) => void;
+  isMerging: boolean;
+  onClose: () => void;
+}

--- a/src/hooks/use-engram/hook.ts
+++ b/src/hooks/use-engram/hook.ts
@@ -132,6 +132,17 @@ export const useDeletePrompt = () => {
   });
 };
 
+/** Merge all observations from one project into another. */
+export const useMergeProjects = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ from, to }: { from: string; to: string }) => engramService.mergeProjects(from, to),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['engram'] });
+    }
+  });
+};
+
 /** Export all Engram data as a downloadable JSON file. */
 export const useEngramExport = () =>
   useMutation({

--- a/src/hooks/use-engram/index.ts
+++ b/src/hooks/use-engram/index.ts
@@ -11,6 +11,7 @@ export {
   useEngramSessionSummaries,
   useEngramSessions,
   useEngramStats,
+  useMergeProjects,
   useUpdateObservation
 } from './hook';
 export type { EngramFilters } from './types';

--- a/src/pages/engram-dashboard/EngramDashboardPage.tsx
+++ b/src/pages/engram-dashboard/EngramDashboardPage.tsx
@@ -8,7 +8,8 @@ import {
   useEngramReset,
   useEngramSearch,
   useEngramSessionSummaries,
-  useEngramSessions
+  useEngramSessions,
+  useMergeProjects
 } from '@hooks/use-engram';
 import { useQueryClient } from '@tanstack/react-query';
 import axios from 'axios';
@@ -37,6 +38,7 @@ const EngramDashboardPage = () => {
   const deletePromptMut = useDeletePrompt();
   const exportMutation = useEngramExport();
   const importMutation = useEngramImport();
+  const mergeProjectsMut = useMergeProjects();
 
   const handleFiltersChange = (partial: Partial<EngramFilters>) => {
     setFilters((prev) => ({ ...prev, ...partial }));
@@ -97,6 +99,37 @@ const EngramDashboardPage = () => {
     });
   };
 
+  const handleMergeProjects = (from: string, to: string, onSuccess: () => void) => {
+    mergeProjectsMut.mutate(
+      { from, to },
+      {
+        onSuccess: () => {
+          onSuccess();
+          setTimeout(() => window.alert(`Project "${from}" merged into "${to}" successfully.`), 0);
+        },
+        onError: (err) => {
+          let message = 'Merge failed.';
+          if (axios.isAxiosError(err)) {
+            const responseMessage =
+              typeof err.response?.data === 'string'
+                ? err.response.data
+                : typeof err.response?.data?.message === 'string'
+                  ? err.response.data.message
+                  : undefined;
+            if (err.response?.status === 404) {
+              message = responseMessage ?? `Project "${from}" or "${to}" was not found.`;
+            } else {
+              message = responseMessage ?? err.message;
+            }
+          } else if (err instanceof Error) {
+            message = err.message;
+          }
+          setTimeout(() => window.alert(message), 0);
+        }
+      }
+    );
+  };
+
   const handleDeletePrompt = (id: number) => {
     deletePromptMut.mutate(id, {
       onError: (err) => {
@@ -134,6 +167,8 @@ const EngramDashboardPage = () => {
       isExporting={exportMutation.isPending}
       onImport={handleImport}
       isImporting={importMutation.isPending}
+      onMergeProjects={handleMergeProjects}
+      isMergingProjects={mergeProjectsMut.isPending}
     />
   );
 };

--- a/src/pages/engram-dashboard/EngramDashboardView.tsx
+++ b/src/pages/engram-dashboard/EngramDashboardView.tsx
@@ -3,11 +3,12 @@ import { cn } from '@helpers/utils';
 import { TabBar } from '@molecules/tab-bar';
 import { EmptySessionsTab } from '@organisms/empty-sessions-tab';
 import { MemoriesTab } from '@organisms/memories-tab';
+import { MergeProjectsModal } from '@organisms/merge-projects-modal';
 import { PromptsTab } from '@organisms/prompts-tab';
 import { SessionsTab } from '@organisms/sessions-tab';
 import { TimelineTab } from '@organisms/timeline-tab';
 import { TopicsTab } from '@organisms/topics-tab';
-import { Download, Upload } from 'lucide-react';
+import { Download, GitMerge, Upload } from 'lucide-react';
 import { type FC, useMemo, useRef, useState } from 'react';
 import type { EngramDashboardViewProps } from './types';
 
@@ -32,10 +33,13 @@ export const EngramDashboardView: FC<EngramDashboardViewProps> = ({
   onExport,
   isExporting,
   onImport,
-  isImporting
+  isImporting,
+  onMergeProjects,
+  isMergingProjects
 }) => {
   const [tab, setTab] = useState<Tab>('sessions');
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const [showMerge, setShowMerge] = useState(false);
 
   const allObservations = useMemo(() => sessions.flatMap((s) => s.observations), [sessions]);
 
@@ -124,6 +128,35 @@ export const EngramDashboardView: FC<EngramDashboardViewProps> = ({
           }}
         />
       </div>
+
+      {/* Merge projects button */}
+      {derivedStats.allProjects.length > 1 && (
+        <div className='flex items-center'>
+          <button
+            type='button'
+            onClick={() => setShowMerge(true)}
+            className={cn(
+              'flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-[11px] font-mono',
+              'bg-gray-light-100 dark:bg-gray-dark-800',
+              'border border-gray-light-400 dark:border-gray-dark-600',
+              'text-text-light dark:text-text-dark',
+              'hover:border-accent/60 hover:bg-accent/10 transition-colors'
+            )}
+          >
+            <GitMerge size={12} />
+            Merge Projects
+          </button>
+        </div>
+      )}
+
+      {showMerge && (
+        <MergeProjectsModal
+          projects={derivedStats.allProjects}
+          onMerge={(from, to) => onMergeProjects(from, to, () => setShowMerge(false))}
+          isMerging={isMergingProjects}
+          onClose={() => { if (!isMergingProjects) setShowMerge(false); }}
+        />
+      )}
 
       {/* Tabs */}
       <TabBar tabs={tabs} active={tab} onChange={(id) => setTab(id as Tab)} />

--- a/src/pages/engram-dashboard/types.ts
+++ b/src/pages/engram-dashboard/types.ts
@@ -22,6 +22,6 @@ export interface EngramDashboardViewProps {
   isExporting: boolean;
   onImport: (file: File) => void;
   isImporting: boolean;
-  onMergeProjects: (from: string, to: string, onSuccess: () => void) => void;
+  onMergeProjects: (from: string, to: string) => void;
   isMergingProjects: boolean;
 }

--- a/src/pages/engram-dashboard/types.ts
+++ b/src/pages/engram-dashboard/types.ts
@@ -22,4 +22,6 @@ export interface EngramDashboardViewProps {
   isExporting: boolean;
   onImport: (file: File) => void;
   isImporting: boolean;
+  onMergeProjects: (from: string, to: string, onSuccess: () => void) => void;
+  isMergingProjects: boolean;
 }

--- a/src/services/engram.ts
+++ b/src/services/engram.ts
@@ -172,5 +172,10 @@ export const engramService = {
       headers: { 'Content-Type': 'application/json' },
       timeout: 60_000
     });
+  },
+
+  /** Merges all observations from one project into another. */
+  mergeProjects: async (from: string, to: string): Promise<void> => {
+    await engramApi.post('/projects/migrate', { from, to });
   }
 };

--- a/src/services/engram.ts
+++ b/src/services/engram.ts
@@ -176,6 +176,6 @@ export const engramService = {
 
   /** Merges all observations from one project into another. */
   mergeProjects: async (from: string, to: string): Promise<void> => {
-    await engramApi.post('/projects/migrate', { from, to });
+    await engramApi.post('/projects/migrate', { from, to }, { timeout: 60_000 });
   }
 };


### PR DESCRIPTION
## Summary
- Added a Merge Projects modal to consolidate duplicate project names
- Button appears between stats bar and tabs when 2+ projects exist
- Source and target dropdowns with arrow indicator
- Confirmation dialog before destructive merge operation

## Use case
When Engram stores observations under variant names (e.g. `capilla-negra`, `Capilla-Negra`, `la-capilla-negra`), this UI lets you merge them into a single canonical project name without using the CLI.

## Implementation
- New `MergeProjectsModal` organism component (Atomic Design)
- `mergeProjects` method in engramService using POST /projects/migrate
- `useMergeProjects` hook with React Query mutation + full cache invalidation
- Target dropdown excludes the selected source project
- Esc to close, overlay click to close

## Files changed
- src/components/organisms/merge-projects-modal/ (new) - Modal component
- src/services/engram.ts - Added mergeProjects method
- src/hooks/use-engram/hook.ts - Added useMergeProjects hook
- src/hooks/use-engram/index.ts - Exported new hook
- src/pages/engram-dashboard/types.ts - Added merge props
- src/pages/engram-dashboard/EngramDashboardPage.tsx - Wired merge handler
- src/pages/engram-dashboard/EngramDashboardView.tsx - Added button + modal