### PR TITLE
feat: Topics tab with topic_key grouping

### DIFF
--- a/src/components/organisms/topics-tab/TopicsTab.tsx
+++ b/src/components/organisms/topics-tab/TopicsTab.tsx
@@ -1,0 +1,220 @@
+import { EmptyState } from '@atoms/empty-state';
+import { FilterSelect } from '@atoms/filter-select';
+import { SearchInput } from '@atoms/search-input';
+import { TypeBadge } from '@atoms/type-badge';
+import { cn } from '@helpers/utils';
+import type { EngramObservation } from '@models/engram';
+import { MarkdownPanel } from '@molecules/markdown-panel';
+import { ChevronDown, ChevronRight, FolderOpen, Tag } from 'lucide-react';
+import { type FC, useMemo, useState } from 'react';
+import type { TopicsTabProps } from './types';
+
+interface TopicGroup {
+  topicKey: string;
+  observations: EngramObservation[];
+  projects: string[];
+  types: string[];
+  latestDate: string;
+}
+
+const TopicsTab: FC<TopicsTabProps> = ({ observations, loading, allProjects }) => {
+  const [search, setSearch] = useState('');
+  const [projectFilter, setProjectFilter] = useState('');
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const [selected, setSelected] = useState<EngramObservation | null>(null);
+
+  const groups = useMemo(() => {
+    // Only observations with a topic_key
+    const withTopic = observations.filter((o) => o.topic_key);
+    const map = new Map<string, EngramObservation[]>();
+
+    for (const obs of withTopic) {
+      const key = obs.topic_key as string;
+      const list = map.get(key) ?? [];
+      list.push(obs);
+      map.set(key, list);
+    }
+
+    const result: TopicGroup[] = [];
+    for (const [topicKey, obs] of map) {
+      const sorted = [...obs].sort((a, b) => a.created_at.localeCompare(b.created_at));
+      result.push({
+        topicKey,
+        observations: sorted,
+        projects: Array.from(new Set(sorted.map((o) => o.project))),
+        types: Array.from(new Set(sorted.map((o) => o.type))),
+        latestDate: sorted.at(-1)?.created_at ?? ''
+      });
+    }
+
+    return result.sort((a, b) => b.latestDate.localeCompare(a.latestDate));
+  }, [observations]);
+
+  const filtered = useMemo(() => {
+    let result = groups;
+    if (projectFilter) {
+      result = result.filter((g) => g.projects.includes(projectFilter));
+    }
+    if (search) {
+      const q = search.toLowerCase();
+      result = result.filter(
+        (g) =>
+          g.topicKey.toLowerCase().includes(q) ||
+          g.observations.some((o) => o.title.toLowerCase().includes(q) || o.content.toLowerCase().includes(q))
+      );
+    }
+    return result;
+  }, [groups, projectFilter, search]);
+
+  const toggleExpand = (key: string) => {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  };
+
+  const projectOptions = [{ value: '', label: 'All projects' }, ...allProjects.map((p) => ({ value: p, label: p }))];
+
+  if (loading && observations.length === 0) {
+    return (
+      <div className='flex flex-col gap-3'>
+        {Array.from({ length: 4 }, (_, i) => `sk-${i}`).map((k) => (
+          <div
+            key={k}
+            className={cn(
+              'h-16 rounded-lg animate-pulse border',
+              'bg-gray-light-200 dark:bg-gray-dark-800',
+              'border-gray-light-300 dark:border-gray-dark-700'
+            )}
+          />
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <>
+      {/* Filters */}
+      <div className='flex flex-col gap-3'>
+        <SearchInput value={search} onChange={setSearch} placeholder='Search by topic key, title, content…' />
+        <div className='flex items-center gap-3 flex-wrap'>
+          <FilterSelect label='project' value={projectFilter} onChange={setProjectFilter} options={projectOptions} />
+          <span className='text-[11px] font-mono text-gray-light-500 dark:text-gray-dark-300 ml-auto'>
+            {filtered.length} topic{filtered.length !== 1 ? 's' : ''}
+            {groups.length !== filtered.length ? ` / ${groups.length} total` : ''}
+          </span>
+        </div>
+      </div>
+
+      {/* Groups */}
+      {filtered.length === 0 ? (
+        <EmptyState message={search || projectFilter ? 'No topics match the current filters' : 'No topic keys found'} />
+      ) : (
+        <div className='flex flex-col gap-2'>
+          {filtered.map((group) => {
+            const isOpen = expanded.has(group.topicKey);
+            return (
+              <div
+                key={group.topicKey}
+                className={cn(
+                  'rounded-lg border overflow-hidden',
+                  'border-gray-light-300 dark:border-gray-dark-700',
+                  'bg-gray-light-100/50 dark:bg-gray-dark-800/50'
+                )}
+              >
+                {/* Group header */}
+                <button
+                  type='button'
+                  onClick={() => toggleExpand(group.topicKey)}
+                  className={cn(
+                    'w-full flex items-center gap-3 px-4 py-3 text-left cursor-pointer',
+                    'hover:bg-gray-light-200/50 dark:hover:bg-gray-dark-700/50 transition-colors'
+                  )}
+                >
+                  {isOpen ? (
+                    <ChevronDown size={14} className='text-gray-light-500 dark:text-gray-dark-300 shrink-0' />
+                  ) : (
+                    <ChevronRight size={14} className='text-gray-light-500 dark:text-gray-dark-300 shrink-0' />
+                  )}
+
+                  <Tag size={12} className='text-accent shrink-0' />
+
+                  <span className='text-[13px] font-mono font-medium text-text-light dark:text-text-dark truncate'>
+                    {group.topicKey}
+                  </span>
+
+                  <div className='flex items-center gap-1.5 ml-auto shrink-0'>
+                    {group.projects.map((p) => (
+                      <span
+                        key={p}
+                        className='inline-flex items-center gap-1 text-[10px] font-mono text-gray-light-600 dark:text-gray-dark-300'
+                      >
+                        <FolderOpen size={9} className='opacity-60' />
+                        {p}
+                      </span>
+                    ))}
+                    <span className='text-[10px] font-mono text-gray-light-500 dark:text-gray-dark-300 tabular-nums'>
+                      {group.observations.length} obs
+                    </span>
+                    {group.types.slice(0, 3).map((t) => (
+                      <TypeBadge key={t} type={t} />
+                    ))}
+                  </div>
+                </button>
+
+                {/* Expanded observations */}
+                {isOpen && (
+                  <div className='border-t border-gray-light-300 dark:border-gray-dark-700'>
+                    {group.observations.map((obs, i) => (
+                      <button
+                        key={obs.id}
+                        type='button'
+                        onClick={() => setSelected(obs)}
+                        className={cn(
+                          'w-full flex items-center gap-3 px-4 py-2.5 text-left cursor-pointer',
+                          'hover:bg-gray-light-200/50 dark:hover:bg-gray-dark-700/50 transition-colors',
+                          i > 0 && 'border-t border-gray-light-200 dark:border-gray-dark-700/50'
+                        )}
+                      >
+                        {/* Timeline dot */}
+                        <div className='flex flex-col items-center gap-0.5 shrink-0 w-4'>
+                          <div className='w-2 h-2 rounded-full bg-accent/60' />
+                          {i < group.observations.length - 1 && (
+                            <div className='w-px h-3 bg-gray-light-300 dark:bg-gray-dark-600' />
+                          )}
+                        </div>
+
+                        <div className='flex flex-col gap-0.5 min-w-0 flex-1'>
+                          <span className='text-[12px] text-text-light dark:text-text-dark truncate'>
+                            {obs.title}
+                          </span>
+                          <span className='text-[10px] font-mono text-gray-light-500 dark:text-gray-dark-300'>
+                            {new Date(obs.created_at).toLocaleString()}
+                          </span>
+                        </div>
+
+                        <TypeBadge type={obs.type} />
+
+                        {obs.revision_count > 0 && (
+                          <span className='text-[9px] font-mono text-gray-light-400 dark:text-gray-dark-300 shrink-0'>
+                            rev {obs.revision_count}
+                          </span>
+                        )}
+                      </button>
+                    ))}
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {selected && <MarkdownPanel observation={selected} onClose={() => setSelected(null)} />}
+    </>
+  );
+};
+
+export default TopicsTab;

--- a/src/components/organisms/topics-tab/TopicsTab.tsx
+++ b/src/components/organisms/topics-tab/TopicsTab.tsx
@@ -115,6 +115,7 @@ const TopicsTab: FC<TopicsTabProps> = ({ observations, loading, allProjects }) =
         <div className='flex flex-col gap-2'>
           {filtered.map((group) => {
             const isOpen = expanded.has(group.topicKey);
+            const panelId = `topic-panel-${group.topicKey.replace(/[^a-zA-Z0-9-]/g, '-')}`;
             return (
               <div
                 key={group.topicKey}
@@ -128,6 +129,8 @@ const TopicsTab: FC<TopicsTabProps> = ({ observations, loading, allProjects }) =
                 <button
                   type='button'
                   onClick={() => toggleExpand(group.topicKey)}
+                  aria-expanded={isOpen}
+                  aria-controls={panelId}
                   className={cn(
                     'w-full flex items-center gap-3 px-4 py-3 text-left cursor-pointer',
                     'hover:bg-gray-light-200/50 dark:hover:bg-gray-dark-700/50 transition-colors'
@@ -166,7 +169,7 @@ const TopicsTab: FC<TopicsTabProps> = ({ observations, loading, allProjects }) =
 
                 {/* Expanded observations */}
                 {isOpen && (
-                  <div className='border-t border-gray-light-300 dark:border-gray-dark-700'>
+                  <div id={panelId} className='border-t border-gray-light-300 dark:border-gray-dark-700'>
                     {group.observations.map((obs, i) => (
                       <button
                         key={obs.id}

--- a/src/components/organisms/topics-tab/TopicsTab.tsx
+++ b/src/components/organisms/topics-tab/TopicsTab.tsx
@@ -40,11 +40,11 @@ const TopicsTab: FC<TopicsTabProps> = ({ observations, loading, allProjects }) =
     const result: TopicGroup[] = [];
     for (const [topicKey, obs] of map) {
       const sorted = [...obs].sort((a, b) => a.created_at.localeCompare(b.created_at));
-      const searchText = [topicKey, ...sorted.map((o) => `${o.title} ${o.content}`)].join(' ').toLowerCase();
+      const searchText = [topicKey, ...sorted.map((o) => o.title)].join(' ').toLowerCase();
       result.push({
         topicKey,
         observations: sorted,
-        projects: Array.from(new Set(sorted.map((o) => o.project))),
+        projects: Array.from(new Set(sorted.map((o) => o.project).filter(Boolean))),
         types: Array.from(new Set(sorted.map((o) => o.type))),
         latestDate: sorted.at(-1)?.created_at ?? '',
         searchText
@@ -113,9 +113,9 @@ const TopicsTab: FC<TopicsTabProps> = ({ observations, loading, allProjects }) =
         <EmptyState message={search || projectFilter ? 'No topics match the current filters' : 'No topic keys found'} />
       ) : (
         <div className='flex flex-col gap-2'>
-          {filtered.map((group, groupIdx) => {
+          {filtered.map((group) => {
             const isOpen = expanded.has(group.topicKey);
-            const panelId = `topic-panel-${groupIdx}`;
+            const panelId = `topic-panel-${encodeURIComponent(group.topicKey)}`;
             return (
               <div
                 key={group.topicKey}

--- a/src/components/organisms/topics-tab/TopicsTab.tsx
+++ b/src/components/organisms/topics-tab/TopicsTab.tsx
@@ -3,7 +3,7 @@ import { FilterSelect } from '@atoms/filter-select';
 import { SearchInput } from '@atoms/search-input';
 import { TypeBadge } from '@atoms/type-badge';
 import { cn } from '@helpers/utils';
-import type { EngramObservation } from '@models/engram';
+import type { EngramObservation, EngramObservationType } from '@models/engram';
 import { MarkdownPanel } from '@molecules/markdown-panel';
 import { ChevronDown, ChevronRight, FolderOpen, Tag } from 'lucide-react';
 import { type FC, useMemo, useState } from 'react';
@@ -13,8 +13,10 @@ interface TopicGroup {
   topicKey: string;
   observations: EngramObservation[];
   projects: string[];
-  types: string[];
+  types: EngramObservationType[];
   latestDate: string;
+  /** Precomputed lowercase search text for filtering performance. */
+  searchText: string;
 }
 
 const TopicsTab: FC<TopicsTabProps> = ({ observations, loading, allProjects }) => {
@@ -38,12 +40,14 @@ const TopicsTab: FC<TopicsTabProps> = ({ observations, loading, allProjects }) =
     const result: TopicGroup[] = [];
     for (const [topicKey, obs] of map) {
       const sorted = [...obs].sort((a, b) => a.created_at.localeCompare(b.created_at));
+      const searchText = [topicKey, ...sorted.map((o) => `${o.title} ${o.content}`)].join(' ').toLowerCase();
       result.push({
         topicKey,
         observations: sorted,
         projects: Array.from(new Set(sorted.map((o) => o.project))),
         types: Array.from(new Set(sorted.map((o) => o.type))),
-        latestDate: sorted.at(-1)?.created_at ?? ''
+        latestDate: sorted.at(-1)?.created_at ?? '',
+        searchText
       });
     }
 
@@ -57,11 +61,7 @@ const TopicsTab: FC<TopicsTabProps> = ({ observations, loading, allProjects }) =
     }
     if (search) {
       const q = search.toLowerCase();
-      result = result.filter(
-        (g) =>
-          g.topicKey.toLowerCase().includes(q) ||
-          g.observations.some((o) => o.title.toLowerCase().includes(q) || o.content.toLowerCase().includes(q))
-      );
+      result = result.filter((g) => g.searchText.includes(q));
     }
     return result;
   }, [groups, projectFilter, search]);
@@ -113,9 +113,9 @@ const TopicsTab: FC<TopicsTabProps> = ({ observations, loading, allProjects }) =
         <EmptyState message={search || projectFilter ? 'No topics match the current filters' : 'No topic keys found'} />
       ) : (
         <div className='flex flex-col gap-2'>
-          {filtered.map((group) => {
+          {filtered.map((group, groupIdx) => {
             const isOpen = expanded.has(group.topicKey);
-            const panelId = `topic-panel-${group.topicKey.replace(/[^a-zA-Z0-9-]/g, '-')}`;
+            const panelId = `topic-panel-${groupIdx}`;
             return (
               <div
                 key={group.topicKey}

--- a/src/components/organisms/topics-tab/index.ts
+++ b/src/components/organisms/topics-tab/index.ts
@@ -1,0 +1,2 @@
+export { default as TopicsTab } from './TopicsTab';
+export type { TopicsTabProps } from './types';

--- a/src/components/organisms/topics-tab/types.ts
+++ b/src/components/organisms/topics-tab/types.ts
@@ -1,0 +1,7 @@
+import type { EngramObservation } from '@models/engram';
+
+export interface TopicsTabProps {
+  observations: EngramObservation[];
+  loading: boolean;
+  allProjects: string[];
+}

--- a/src/pages/engram-dashboard/EngramDashboardView.tsx
+++ b/src/pages/engram-dashboard/EngramDashboardView.tsx
@@ -4,10 +4,11 @@ import { EmptySessionsTab } from '@organisms/empty-sessions-tab';
 import { MemoriesTab } from '@organisms/memories-tab';
 import { PromptsTab } from '@organisms/prompts-tab';
 import { SessionsTab } from '@organisms/sessions-tab';
+import { TopicsTab } from '@organisms/topics-tab';
 import { type FC, useMemo, useState } from 'react';
 import type { EngramDashboardViewProps } from './types';
 
-type Tab = 'sessions' | 'memories' | 'prompts' | 'empty';
+type Tab = 'sessions' | 'memories' | 'topics' | 'prompts' | 'empty';
 
 export const EngramDashboardView: FC<EngramDashboardViewProps> = ({
   observations,
@@ -29,23 +30,28 @@ export const EngramDashboardView: FC<EngramDashboardViewProps> = ({
   const [tab, setTab] = useState<Tab>('sessions');
 
   // ── Stats derived from what the panel actually shows ──────────────────────
+  const allObservations = useMemo(() => sessions.flatMap((s) => s.observations), [sessions]);
+
   const derivedStats = useMemo(() => {
     const totalObs = sessions.reduce((acc, s) => acc + s.observationCount, 0);
     const projects = Array.from(new Set(sessions.map((s) => s.project).filter(Boolean)));
     const emptySessions = sessionSummaries.filter((s) => s.observation_count === 0);
+    const topicKeys = new Set(allObservations.filter((o) => o.topic_key).map((o) => o.topic_key));
     return {
       projects: projects.length,
       sessions: sessions.length,
       observations: totalObs,
       prompts: prompts.length,
       empty: emptySessions.length,
+      topics: topicKeys.size,
       allProjects: projects
     };
-  }, [sessions, sessionSummaries, prompts]);
+  }, [sessions, sessionSummaries, prompts, allObservations]);
 
   const tabs = [
     { id: 'sessions' as Tab, label: 'Sessions', count: derivedStats.sessions },
     { id: 'memories' as Tab, label: 'Memories', count: derivedStats.observations },
+    { id: 'topics' as Tab, label: 'Topics', count: derivedStats.topics },
     { id: 'prompts' as Tab, label: 'Prompts', count: derivedStats.prompts },
     { id: 'empty' as Tab, label: 'Empty', count: derivedStats.empty }
   ];
@@ -75,6 +81,13 @@ export const EngramDashboardView: FC<EngramDashboardViewProps> = ({
           onFiltersChange={onFiltersChange}
           isLoading={isLoadingObs}
           projects={derivedStats.allProjects}
+        />
+      )}
+      {tab === 'topics' && (
+        <TopicsTab
+          observations={allObservations}
+          loading={isLoadingSessions}
+          allProjects={derivedStats.allProjects}
         />
       )}
       {tab === 'prompts' && (


### PR DESCRIPTION
## Summary
- New Topics tab that groups observations sharing the same `topic_key`
- Shows how decisions and discoveries evolve over time within a topic
- Collapsible accordion with chronological timeline view

## Features
- Accordion groups sorted by most recent activity
- Each group shows: topic key, project badges, type badges, observation count
- Expanded view: timeline dots, observation title, date, type, revision count
- Click any observation to open the markdown detail panel
- Search by topic key, title, or content
- Project filter dropdown
- Topic count shown in tab badge

## Use case
Observations with the same `topic_key` represent the evolution of a single topic (e.g. `architecture/auth-model`). This tab makes it easy to see the full history of decisions, updates, and refinements on any topic — something not visible in the flat Memories list.

## Files changed
- src/components/organisms/topics-tab/ (new) - TopicsTab component + types + index
- src/pages/engram-dashboard/EngramDashboardView.tsx - Added Topics tab, derived allObservations and topic count